### PR TITLE
Update production instructions

### DIFF
--- a/tutorials/prod_install.md
+++ b/tutorials/prod_install.md
@@ -183,10 +183,14 @@ Ensuite, indiquer le mot de passe du compte administrateur (qui sera désactivé
 
 -   `python3 manage.py shell`,
 -   `from users.models import User`,
--   `u = User.objects.get(pk=2)`,
+-   `u = User.objects.get(pk=1)`,
 -   `u.set_password(NEW_PASSWORD)`.
 -   `u.save()`
 -   `exit()`
+
+Les identifiants de ce compte seront:
+- Nom d'utilisateur: `AE_ENSAM`
+- Mot de passe défini ci-dessus
 
 #### Test intermédiaire
 

--- a/tutorials/prod_install.md
+++ b/tutorials/prod_install.md
@@ -241,6 +241,18 @@ Ajoutez cette ligne à la fin du fichier (avant le `exit 0`) `/etc/rc.local`:
 
 `/usr/local/bin/uwsgi --emperor /etc/uwsgi/vassals`
 
+Le fichier `/etc/rc.local` a donc l'allure suivante:
+
+`#!/bin/sh -e`
+
+`/usr/local/bin/uwsgi --emperor /etc/uwsgi/vassals`
+
+`exit 0`
+
+Il faut ensuite le rendre exécutable:
+
+`chmod 755 /etc/rc.local`
+
 #### Sauvegarde dans git
 
 Enfin, il convient de sauvegarder l'ensemble de cette configuration sur une branche de production (sudo non nécessaire ici) :

--- a/tutorials/prod_install.md
+++ b/tutorials/prod_install.md
@@ -110,6 +110,8 @@ Ensuite dans `/borgia-app/Borgia` :
 Dans `/borgia-app/Borgia` et dans l'environnement virtuel :
 
 -   `pip3 install -r requirements/prod.txt`
+-   `pip3 uninstall psycopg2`
+-   `pip3 install --no-binary :all: psycopg2`
 
 Et finalement, hors de l'environnement virtuel :
 


### PR DESCRIPTION
En production, il existe des incohérences dans la méthode d'installation.

- Les identifiants du premier compte ne sont pas spécifiés, je les ai ajouté
- La clé primaire du premier utilisateur est pk=1, j'ai corrigé en conséquence
- L'installation de psycopg via requirements.txt lève une exception (SEGMENTATION FAULT) au chargement de pages, une installation manuelle sans wheel à partir des binaires résoud simplement le problème, j'ai donc corrigé le document d'installation
     => On pourrait peut-être corriger directement le requirements.txt
- La structure de rc.local n'était pas clair et il manquait la nécessité de le rendre exécutable